### PR TITLE
Add API versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 [API_VERSIONING.md](./docs/API_VERSIONING.md) 참고
 
+## 코드 작성시 유의 사항
+
+API 엔드포인트 작성시 엔드포인트 맨 앞에 `/api`를 반드시 포함해야 합니다.
+
+현재 [WebConfig.java](../src/main/java/com/sesac/carematching/config/WebConfig.java)에서 `new ApiVersionRMHM("/api")`를 실행하기 때문에 모든 엔드포인트에 대해 `/api` prefix가 필요합니다.
+
+컨트롤러 코드를 보고 API 엔드포인트를 바로 이해할 수 있도록 코드 가독성을 위해 컨트롤러에 모두 접두사 `/api`를 직접 작성하는 방식으로 작성했습니다.
+
 ## Production 환경으로 실행
 
 ### Java 명령어를 통해 직접 옵션 주기
 `java -Dspring.profiles.active=prod -jar "app.jar"`
 
 ### 환경 변수를 통해 옵션 주기
-`SPRING_PROFILES_ACTIVE=prod` 를 .env 파일에 추가하거나  
-환경 변수에 적용해주면 된다.
+`SPRING_PROFILES_ACTIVE=prod` 를 .env 파일에 추가하거나 환경 변수에 적용해주면 됩니다.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
+## API 버전 관리 시스템
+
+이 프로젝트는 Spring MVC에서 효율적인 API 버전 관리를 위한 표준 확장 방식을 구현했습니다.
+
+[API_VERSIONING.md](./docs/API_VERSIONING.md) 참고
+
 ## Production 환경으로 실행
 
 ### Java 명령어를 통해 직접 옵션 주기
-`java -Dspring.profiles.active=prod -jar app.jar"`
+`java -Dspring.profiles.active=prod -jar "app.jar"`
 
 ### 환경 변수를 통해 옵션 주기
 `SPRING_PROFILES_ACTIVE=prod` 를 .env 파일에 추가하거나  

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,80 @@
+# API 버전 관리 시스템
+
+이 프로젝트는 Spring MVC에서 효율적인 API 버전 관리를 위한 표준 확장 방식을 구현했습니다.
+
+## 주요 기능
+
+- 단일 컨트롤러로 여러 API 버전 지원
+- 버전별 코드 중복 없음
+- 새 버전 추가 시 기존 코드 수정 최소화
+- 이전 버전과의 호환성 유지
+
+## 구성 요소
+
+### 1. ApiVersion 어노테이션
+
+컨트롤러 클래스나 메서드에 적용하여 지원하는 API 버전을 지정합니다.
+
+```java
+@RestController
+@RequestMapping("/api/messages")
+@ApiVersion({1, 2})  // v1과 v2 API 버전 모두 지원
+public class MessageController {
+    // ...
+}
+```
+
+### 2. ApiVersionRequestMappingHandlerMapping
+
+Spring의 RequestMappingHandlerMapping을 확장하여 API 버전 정보를 URL 경로에 추가합니다.
+
+### 3. WebConfig 설정
+
+- WebMvcRegistrations 인터페이스를 구현하여 커스텀 핸들러 매핑 등록
+- 버전이 없는 요청을 v1 엔드포인트로 포워딩하는 필터 제공
+
+## 사용 방법
+
+### 새 컨트롤러에 버전 적용하기
+
+```java
+import com.sesac.carematching.config.ApiVersion;
+
+@RestController
+@RequestMapping("/api/resources")  // 버전 없는 기본 경로 사용
+@ApiVersion({1, 2})  // 지원하는 버전 명시
+public class ResourceController {
+
+    @GetMapping
+    public List<Resource> getResources() {
+        // 이 메서드는 /api/v1/resources와 /api/v2/resources 모두에서 접근 가능
+        return resourceService.findAll();
+    }
+    
+    @PostMapping
+    @ApiVersion({2})  // 메서드 레벨에서 버전 지정 (v2에서만 사용 가능)
+    public Resource createResource(@RequestBody ResourceDto dto) {
+        // 이 메서드는 /api/v2/resources에서만 접근 가능
+        return resourceService.create(dto);
+    }
+}
+```
+
+### 새 버전 추가하기
+
+새로운 API 버전(v3)을 추가하려면:
+
+1. 기존 컨트롤러에 새 버전 추가:
+```java
+@ApiVersion({1, 2, 3})  // v3 추가
+```
+
+2. 새 버전에서만 사용할 메서드 추가:
+```java
+@GetMapping("/enhanced")
+@ApiVersion({3})  // v3에서만 사용 가능
+public EnhancedResource getEnhancedResource() {
+    // v3 전용 기능
+    return resourceService.getEnhanced();
+}
+```

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -71,7 +71,7 @@ public class ResourceController {
 
 2. 새 버전에서만 사용할 메서드 추가:
 ```java
-@GetMapping("/enhanced")
+@GetMapping("/api/enhanced")
 @ApiVersion({3})  // v3에서만 사용 가능
 public EnhancedResource getEnhancedResource() {
     // v3 전용 기능

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -33,7 +33,7 @@ public class CommonController {
 }
 ```
 
-### 2. ApiVersionRequestMappingHandlerMapping
+### 2. ApiVersionRMHM
 
 Spring의 RequestMappingHandlerMapping을 확장하여 API 버전 정보를 URL 경로에 추가합니다.
 

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -8,12 +8,13 @@
 - 버전별 코드 중복 없음
 - 새 버전 추가 시 기존 코드 수정 최소화
 - 이전 버전과의 호환성 유지
+- 버전 지정이 없는 경우 모든 버전 지원
 
 ## 구성 요소
 
 ### 1. ApiVersion 어노테이션
 
-컨트롤러 클래스나 메서드에 적용하여 지원하는 API 버전을 지정합니다.
+컨트롤러 클래스나 메서드에 적용하여 지원하는 API 버전을 지정합니다. 어노테이션을 사용하지 않는 경우, 해당 엔드포인트는 모든 버전에서 접근 가능합니다.
 
 ```java
 @RestController
@@ -21,6 +22,14 @@
 @ApiVersion({1, 2})  // v1과 v2 API 버전 모두 지원
 public class MessageController {
     // ...
+}
+
+@RestController
+@RequestMapping("/api/common")
+// @ApiVersion 어노테이션 없음 - 모든 버전에서 접근 가능
+public class CommonController {
+    // 이 컨트롤러는 /api/common과 /api/v{any}/common 모두에서 접근 가능
+    // 예: /api/common, /api/v1/common, /api/v2/common, /api/v3/common 등
 }
 ```
 
@@ -34,6 +43,36 @@ Spring의 RequestMappingHandlerMapping을 확장하여 API 버전 정보를 URL 
 - 버전이 없는 요청을 v1 엔드포인트로 포워딩하는 필터 제공
 
 ## 사용 방법
+
+### 버전 관리 방식
+
+1. **버전 지정이 필요한 경우**:
+```java
+@RestController
+@RequestMapping("/api/resources")
+@ApiVersion({1, 2})  // 이 컨트롤러는 v1과 v2 버전만 지원
+public class ResourceController {
+    // ...
+}
+```
+
+2. **모든 버전에서 접근 가능하게 하려는 경우**:
+```java
+@RestController
+@RequestMapping("/api/common")
+// @ApiVersion 어노테이션을 사용하지 않음
+public class CommonController {
+    @GetMapping
+    public CommonResponse getCommonData() {
+        // 이 메서드는 다음 URL 모두에서 접근 가능:
+        // - /api/common
+        // - /api/v1/common
+        // - /api/v2/common
+        // - /api/v{any}/common
+        return commonService.getData();
+    }
+}
+```
 
 ### 새 컨트롤러에 버전 적용하기
 

--- a/src/main/java/com/sesac/carematching/caregiver/CaregiverController.java
+++ b/src/main/java/com/sesac/carematching/caregiver/CaregiverController.java
@@ -1,15 +1,15 @@
 package com.sesac.carematching.caregiver;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sesac.carematching.caregiver.dto.CaregiverListDto;
-import com.sesac.carematching.caregiver.dto.CaregiverDetailDto;
 import com.sesac.carematching.caregiver.dto.BuildCaregiverDto;
+import com.sesac.carematching.caregiver.dto.CaregiverDetailDto;
+import com.sesac.carematching.caregiver.dto.CaregiverListDto;
 import com.sesac.carematching.caregiver.experience.Experience;
 import com.sesac.carematching.caregiver.experience.ExperienceRequest;
 import com.sesac.carematching.caregiver.experience.ExperienceService;
 import com.sesac.carematching.caregiver.review.ReviewService;
-import com.sesac.carematching.user.role.RoleService;
+import com.sesac.carematching.config.ApiVersion;
 import com.sesac.carematching.util.S3UploadService;
+import com.sesac.carematching.util.TokenAuth;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -17,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import com.sesac.carematching.util.TokenAuth;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -30,6 +29,7 @@ import java.util.stream.IntStream;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/caregivers")
+@ApiVersion({1, 2})
 @Log4j2
 public class CaregiverController {
     private final CaregiverService caregiverService;

--- a/src/main/java/com/sesac/carematching/caregiver/CaregiverController.java
+++ b/src/main/java/com/sesac/carematching/caregiver/CaregiverController.java
@@ -29,7 +29,6 @@ import java.util.stream.IntStream;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/caregivers")
-@ApiVersion({1, 2})
 @Log4j2
 public class CaregiverController {
     private final CaregiverService caregiverService;

--- a/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/messages")
-@ApiVersion({1, 2})
 @RequiredArgsConstructor
 public class MessageController {
 

--- a/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.sesac.carematching.chat.controller;
 import com.sesac.carematching.chat.dto.MessageRequest;
 import com.sesac.carematching.chat.dto.MessageResponse;
 import com.sesac.carematching.chat.service.MessageService;
+import com.sesac.carematching.config.ApiVersion;
 import com.sesac.carematching.user.User;
 import com.sesac.carematching.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/messages")
+@ApiVersion({1, 2})
 @RequiredArgsConstructor
 public class MessageController {
 

--- a/src/main/java/com/sesac/carematching/chat/controller/NotificationController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.chat.controller;
 
+import com.sesac.carematching.config.ApiVersion;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
+@ApiVersion({1, 2})
 public class NotificationController {
 
     private final SimpMessagingTemplate messagingTemplate;

--- a/src/main/java/com/sesac/carematching/chat/controller/NotificationController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/NotificationController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
-@ApiVersion({1, 2})
 public class NotificationController {
 
     private final SimpMessagingTemplate messagingTemplate;

--- a/src/main/java/com/sesac/carematching/chat/controller/RoomController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/RoomController.java
@@ -3,11 +3,10 @@ package com.sesac.carematching.chat.controller;
 import com.sesac.carematching.chat.dto.CreateRoomRequest;
 import com.sesac.carematching.chat.dto.RoomResponse;
 import com.sesac.carematching.chat.service.RoomService;
-
+import com.sesac.carematching.config.ApiVersion;
 import com.sesac.carematching.util.TokenAuth;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/rooms")
+@ApiVersion({1, 2})
 @RequiredArgsConstructor
 public class RoomController {
 

--- a/src/main/java/com/sesac/carematching/chat/controller/RoomController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/RoomController.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/rooms")
-@ApiVersion({1, 2})
 @RequiredArgsConstructor
 public class RoomController {
 

--- a/src/main/java/com/sesac/carematching/config/ApiVersion.java
+++ b/src/main/java/com/sesac/carematching/config/ApiVersion.java
@@ -1,0 +1,20 @@
+package com.sesac.carematching.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * API 버전을 지정하기 위한 어노테이션
+ * 컨트롤러 클래스나 메서드에 적용할 수 있습니다.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersion {
+    /**
+     * API 버전 배열
+     * 예: {1, 2} - API v1과 v2 모두에서 사용 가능
+     */
+    int[] value();
+}

--- a/src/main/java/com/sesac/carematching/config/ApiVersionRMHM.java
+++ b/src/main/java/com/sesac/carematching/config/ApiVersionRMHM.java
@@ -1,0 +1,69 @@
+package com.sesac.carematching.config;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * API 버전 기반 요청 매핑을 처리하는 핸들러 매핑 클래스
+ * RequestMappingHandlerMapping을 확장하여 API 버전 정보를 URL 경로에 추가합니다.
+ */
+public class ApiVersionRMHM extends RequestMappingHandlerMapping {
+
+    private final String prefix;
+
+    public ApiVersionRMHM(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    protected RequestMappingInfo getMappingForMethod(@NonNull Method method, @NonNull Class<?> handlerType) {
+        RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
+        if (info == null) {
+            return null;
+        }
+
+        // 메서드 또는 클래스에서 ApiVersion 어노테이션 찾기
+        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+        ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
+
+        // 어노테이션이 없으면 기본 매핑 정보 반환
+        if (methodAnnotation == null && typeAnnotation == null) {
+            return info;
+        }
+
+        // 메서드 어노테이션이 있으면 메서드 어노테이션 사용, 없으면 클래스 어노테이션 사용
+        int[] versions = methodAnnotation != null ? methodAnnotation.value() : typeAnnotation.value();
+
+        // 원래 경로 패턴 가져오기
+        String originalPattern = info.getPatternValues().iterator().next();
+
+        Set<String> patterns = getStrings(versions, originalPattern);
+
+        // 원래 RequestMappingInfo의 모든 설정을 유지하면서 경로만 변경
+        return info.mutate()
+            .paths(patterns.toArray(new String[0]))
+            .build();
+    }
+
+    private Set<String> getStrings(int[] versions, String originalPattern) {
+        Set<String> patterns = new HashSet<>();
+
+        // 각 버전에 대한 경로 패턴 생성
+        for (int version : versions) {
+            String versionedPattern = prefix + "/v" + version + originalPattern.substring(prefix.length());
+            patterns.add(versionedPattern);
+
+            // v1인 경우 버전 없는 URL도 추가 (기본값으로 v1 사용)
+            if (version == 1) {
+                patterns.add(originalPattern);
+            }
+        }
+        return patterns;
+    }
+}

--- a/src/main/java/com/sesac/carematching/config/WebConfig.java
+++ b/src/main/java/com/sesac/carematching/config/WebConfig.java
@@ -1,11 +1,20 @@
 package com.sesac.carematching.config;
 
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer, WebMvcRegistrations {
+
+    @Override
+    public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
+        ApiVersionRMHM handlerMapping = new ApiVersionRMHM("/api");
+        handlerMapping.setOrder(0); // 우선순위를 가장 높게 설정
+        return handlerMapping;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/sesac/carematching/config/WebConfig.java
+++ b/src/main/java/com/sesac/carematching/config/WebConfig.java
@@ -11,9 +11,7 @@ public class WebConfig implements WebMvcConfigurer, WebMvcRegistrations {
 
     @Override
     public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
-        ApiVersionRMHM handlerMapping = new ApiVersionRMHM("/api");
-        handlerMapping.setOrder(0); // 우선순위를 가장 높게 설정
-        return handlerMapping;
+        return new ApiVersionRMHM("/api");
     }
 
     @Override

--- a/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
+++ b/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/health")
-@ApiVersion({1, 2})
 public class HealthCheckController {
 
     @GetMapping

--- a/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
+++ b/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
@@ -1,5 +1,6 @@
 package com.sesac.carematching.monitoring;
 
+import com.sesac.carematching.config.ApiVersion;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/health")
+@ApiVersion({1, 2})
 public class HealthCheckController {
 
     @GetMapping


### PR DESCRIPTION
## 주요 기능

- 단일 컨트롤러로 여러 API 버전 지원
- 버전별 코드 중복 없음
- 새 버전 추가 시 기존 코드 수정 최소화
- 이전 버전과의 호환성 유지 (버전 정보가 없는 URL도 지원)
- 버전 지정이 없는 경우 모든 버전 지원

## 구성 요소

### 1. ApiVersion 어노테이션

컨트롤러 클래스나 메서드에 적용하여 지원하는 API 버전을 지정합니다. 어노테이션을 사용하지 않는 경우, 해당 엔드포인트는 모든 버전에서 접근 가능합니다.

```java
@RestController
@RequestMapping("/api/messages")
@ApiVersion({1, 2})  // v1과 v2 API 버전 모두 지원
public class MessageController {
    // ...
}

@RestController
@RequestMapping("/api/common")
// @ApiVersion 어노테이션 없음 - 모든 버전에서 접근 가능
public class CommonController {
    // 이 컨트롤러는 /api/common과 /api/v{any}/common 모두에서 접근 가능
    // 예: /api/common, /api/v1/common, /api/v2/common, /api/v3/common 등
}
```

### 2. ApiVersionRMHM

Spring의 RequestMappingHandlerMapping을 확장하여 API 버전 정보를 URL 경로에 추가합니다.

### 3. WebConfig 설정

- WebMvcRegistrations 인터페이스를 구현하여 커스텀 핸들러 매핑 등록
- 버전이 없는 요청을 v1 엔드포인트로 포워딩하는 필터 제공

## 사용 방법

### 버전 관리 방식

1. **버전 지정이 필요한 경우**:
```java
@RestController
@RequestMapping("/api/resources")
@ApiVersion({1, 2})  // 이 컨트롤러는 v1과 v2 버전만 지원
public class ResourceController {
    // ...
}
```

2. **모든 버전에서 접근 가능하게 하려는 경우**:
```java
@RestController
@RequestMapping("/api/common")
// @ApiVersion 어노테이션을 사용하지 않음
public class CommonController {
    @GetMapping
    public CommonResponse getCommonData() {
        // 이 메서드는 다음 URL 모두에서 접근 가능:
        // - /api/common
        // - /api/v1/common
        // - /api/v2/common
        // - /api/v{any}/common
        return commonService.getData();
    }
}
```

### 새 컨트롤러에 버전 적용하기

```java
import com.sesac.carematching.config.ApiVersion;

@RestController
@RequestMapping("/api/resources")  // 버전 없는 기본 경로 사용
@ApiVersion({1, 2})  // 지원하는 버전 명시
public class ResourceController {

    @GetMapping
    public List<Resource> getResources() {
        // 이 메서드는 /api/v1/resources와 /api/v2/resources 모두에서 접근 가능
        return resourceService.findAll();
    }
    
    @PostMapping
    @ApiVersion({2})  // 메서드 레벨에서 버전 지정 (v2에서만 사용 가능)
    public Resource createResource(@RequestBody ResourceDto dto) {
        // 이 메서드는 /api/v2/resources에서만 접근 가능
        return resourceService.create(dto);
    }
}
```

### 새 버전 추가하기

새로운 API 버전(v3)을 추가하려면:

1. 기존 컨트롤러에 새 버전 추가:
```java
@ApiVersion({1, 2, 3})  // v3 추가
```

2. 새 버전에서만 사용할 메서드 추가:
```java
@GetMapping("/api/enhanced")
@ApiVersion({3})  // v3에서만 사용 가능
public EnhancedResource getEnhancedResource() {
    // v3 전용 기능
    return resourceService.getEnhanced();
}
```
