### PR TITLE
토스 결제 confirm 장애 대응: 임시 저장 및 서킷 브레이커 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    // circuit breaker
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/sesac/carematching/CarematchingApplication.java
+++ b/src/main/java/com/sesac/carematching/CarematchingApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 @EnableJpaRepositories(basePackages = "com.sesac.carematching")
 public class CarematchingApplication {
 

--- a/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
+++ b/src/main/java/com/sesac/carematching/monitoring/HealthCheckController.java
@@ -1,17 +1,22 @@
 package com.sesac.carematching.monitoring;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/health")
 public class HealthCheckController {
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
 
     @GetMapping
     public ResponseEntity<Map<String, Object>> healthCheck() {
@@ -26,6 +31,13 @@ public class HealthCheckController {
             "free", runtime.freeMemory(),
             "used", runtime.totalMemory() - runtime.freeMemory()
         ));
+
+        // Resilience4j CircuitBreaker 상태 수집
+        Map<String, String> circuitBreakers = new HashMap<>();
+        circuitBreakerRegistry.getAllCircuitBreakers().forEach(cb ->
+            circuitBreakers.put(cb.getName(), cb.getState().name())
+        );
+        response.put("circuitBreakers", circuitBreakers);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/sesac/carematching/transaction/TransactionService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionService.java
@@ -17,8 +17,10 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.web.client.ResourceAccessException;
@@ -216,5 +218,33 @@ public class TransactionService {
         pendingPaymentRepository.save(pending);
         log.warn("TossPayments confirm fallback: 결제 임시 저장. orderId={}, reason={}", orderId, t.getMessage());
         return false;
+    }
+
+    // 자동 재시도 주기 (1분)
+    private final static long RETRY_INTERVAL_MILLIS = 60_000L;
+    // 결제 만료 시간 (10분)
+    private final static long PAYMENT_EXPIRE_MINUTES = 10;
+
+    // 자동 재시도 스케줄러
+    @Scheduled(fixedDelay = RETRY_INTERVAL_MILLIS)
+    public void retryPendingPayments() {
+        Instant expireLimit = Instant.now().minusSeconds(PAYMENT_EXPIRE_MINUTES * 60);
+        var pendings = pendingPaymentRepository.findByConfirmedFalseAndCreatedAtAfter(expireLimit);
+        for (PendingPayment pending : pendings) {
+            try {
+                boolean result = verifyTossPayment(pending.getOrderId(), pending.getPrice(), pending.getPaymentKey());
+                if (result) {
+                    pending.setConfirmed(true);
+                    pending.setFailReason(null);
+                    log.info("PendingPayment confirm 성공: orderId={}", pending.getOrderId());
+                } else {
+                    pending.setFailReason("결제 상태가 DONE이 아님");
+                }
+            } catch (Exception e) {
+                pending.setFailReason(e.getMessage());
+                log.warn("PendingPayment confirm 재시도 실패: orderId={}, reason={}", pending.getOrderId(), e.getMessage());
+            }
+            pendingPaymentRepository.save(pending);
+        }
     }
 }

--- a/src/main/java/com/sesac/carematching/transaction/pendingPayment/PendingPayment.java
+++ b/src/main/java/com/sesac/carematching/transaction/pendingPayment/PendingPayment.java
@@ -1,0 +1,59 @@
+package com.sesac.carematching.transaction.pendingPayment;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@Table(name = "pending_payment")
+public class PendingPayment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    @Size(max = 100)
+    @NotNull
+    @Column(name = "ORDER_ID", nullable = false, length = 100)
+    private String orderId;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "PAYMENT_KEY", nullable = false)
+    private String paymentKey;
+
+    @NotNull
+    @Column(name = "PRICE", nullable = false)
+    private Integer price;
+
+    @NotNull
+    @CreatedDate
+    @Column(name = "CREATED_AT", nullable = false)
+    private Instant createdAt;
+
+    @NotNull
+    @Column(name = "CONFIRMED", nullable = false)
+    private Boolean confirmed = false;
+
+    @Size(max = 255)
+    @Column(name = "FAIL_REASON")
+    private String failReason;
+
+    public PendingPayment(String orderId, String paymentKey, Integer price) {
+        this.orderId = orderId;
+        this.paymentKey = paymentKey;
+        this.price = price;
+        this.confirmed = false;
+    }
+}

--- a/src/main/java/com/sesac/carematching/transaction/pendingPayment/PendingPaymentRepository.java
+++ b/src/main/java/com/sesac/carematching/transaction/pendingPayment/PendingPaymentRepository.java
@@ -1,0 +1,10 @@
+package com.sesac.carematching.transaction.pendingPayment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface PendingPaymentRepository extends JpaRepository<PendingPayment, Integer> {
+    List<PendingPayment> findByConfirmedFalseAndCreatedAtAfter(Instant after);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -71,3 +71,14 @@ redis:
 
 toss:
   secret: ${TOSS_SECRET}
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      tossPaymentsConfirm:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 60s
+        permittedNumberOfCallsInHalfOpenState: 3


### PR DESCRIPTION
## 주요 변경 사항

1. **결제 임시 저장(PendingPayment) 시스템 도입**
   - 결제 승인(confirm) 실패 시 결제 정보를 `PendingPayment` 테이블에 임시 저장
   - 결제 승인 대기 상태로 관리, 데이터 유실 방지

2. **Resilience4j 서킷 브레이커 적용**
   - TossPayments confirm API 호출에 서킷 브레이커(`@CircuitBreaker`) 적용
   - 외부 API 장애 시 내부 서비스의 스레드 고갈 및 장애 전파 차단

3. **자동 재시도 스케줄러 구현**
   - 1분마다 PendingPayment 중 미승인 건을 자동으로 재시도
   - 토스 정책에 따라 10분 이내에만 재시도, 이후 만료 처리

4. **HealthCheckController에 CircuitBreaker 상태 수집 기능 추가**
   - `/api/health` 엔드포인트에서 등록된 모든 `Resilience4j CircuitBreaker`의 상태를 자동으로 수집하여 응답에 포함
   - 여러 서킷브레이커가 추가되어도 별도 코드 수정 없이 상태 모니터링 가능

## 기대 효과

- 외부 결제 API 장애 시에도 결제 데이터 유실 없이 안정적으로 처리
- 장애 발생 시 Spring 서버의 스레드 고갈 및 전체 서비스 장애 전파 방지
- 장애 복구 후 자동 재시도를 통한 결제 성공률 및 사용자 경험 향상
- 운영/모니터링 시스템에서 모든 `CircuitBreaker`의 상태를 실시간으로 확인 가능

## 참고
- TossPayments 결제 정책(10분 내 confirm 필요) 반영
- 장애 상황 및 재시도, 만료 처리 등은 로그 및 DB에서 추적 가능
- HealthCheck API를 통한 `CircuitBreaker` 상태 모니터링 지원