### PR TITLE
feat: 결제/트랜잭션 검증 및 RestTemplate 최적화 리팩터링

### DIFF
--- a/src/main/java/com/sesac/carematching/transaction/TossPaymentService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TossPaymentService.java
@@ -85,6 +85,8 @@ public class TossPaymentService {
                 throw new RuntimeException(e);
             }
         }
+        // 결제 정보 임시 저장
+        tossPaymentsFallback(orderId, price, paymentKey, new RuntimeException("3회 재시도 실패"));
         throw new RuntimeException("TossPayments 결제 검증 중 알 수 없는 오류 발생");
     }
 

--- a/src/main/java/com/sesac/carematching/transaction/TransactionService.java
+++ b/src/main/java/com/sesac/carematching/transaction/TransactionService.java
@@ -40,6 +40,7 @@ public class TransactionService {
         return transactionRepository.save(transaction);
     }
 
+    @Transactional(readOnly = true)
     public TransactionGetDTO getValidTransaction(UUID id, String username) {
         Transaction transaction = transactionRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("결제 정보를 찾을 수 없습니다."));
 
@@ -67,6 +68,7 @@ public class TransactionService {
         return transactionGetDTO;
     }
 
+    @Transactional
     public void saveOrderId(UUID transactionId, String orderId, Integer price, String username) {
         Transaction transaction = verifyTransaction(transactionId, price, username);
 
@@ -74,6 +76,7 @@ public class TransactionService {
         transactionRepository.save(transaction);
     }
 
+    @Transactional
     public TransactionVerifyDTO transactionVerify(String orderId, Integer price, String username, String paymentKey) {
         // TossPayments 결제 검증 - TossPaymentService 사용
         boolean isValid = tossPaymentService.verifyTossPayment(orderId, price, paymentKey);


### PR DESCRIPTION
### 주요 변경 내용

- **RestTemplate 인스턴스 사전 생성 및 재사용**
  - RestTemplate 객체를 배열로 미리 초기화하여 런타임 객체 생성 오버헤드 최소화
  - 결제 검증 시 재시도마다 RestTemplate을 새로 만들지 않고, 미리 생성된 인스턴스를 재사용

- **결제 검증 실패 시 임시 저장 로직 추가**
  - TossPayments 결제 검증이 3회 재시도 후에도 실패할 경우, 결제 정보를 PendingPayment에 임시 저장
  - 기존에는 서킷 브레이커가 작동(OPEN)할 때만 임시 저장하는 문제가 있었음

- **TransactionService 메서드에 `@Transactional` 어노테이션 부여**
  - 트랜잭션 처리 범위가 명확해지도록 주요 public 메서드에 `@Transactional` 추가

### 기대 효과

- RestTemplate 객체 재사용으로 인한 성능 개선 및 불필요한 리소스 사용 방지
- 결제 검증 실패 시 데이터 유실 방지 및 추후 재처리 가능

### 기타

- 기능상 변화는 없으며, 코드 품질 및 안정성 개선 목적의 리팩터링입니다.