### PR TITLE
fix: @Transactional import를 jakarta에서 springframework로 변경

### DIFF
--- a/src/main/java/com/sesac/carematching/user/UserService.java
+++ b/src/main/java/com/sesac/carematching/user/UserService.java
@@ -2,13 +2,16 @@ package com.sesac.carematching.user;
 
 import com.sesac.carematching.caregiver.Caregiver;
 import com.sesac.carematching.caregiver.CaregiverRepository;
-import com.sesac.carematching.user.dto.*;
+import com.sesac.carematching.user.dto.UserCertListDTO;
+import com.sesac.carematching.user.dto.UserInfoDTO;
+import com.sesac.carematching.user.dto.UserSignupDTO;
+import com.sesac.carematching.user.dto.UserUpdateDTO;
 import com.sesac.carematching.user.role.RoleService;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 


### PR DESCRIPTION
## @Transactional import 경로 수정

### 변경 내용
- `jakarta.transaction.Transactional` → `org.springframework.transaction.annotation.Transactional`로 import 경로를 변경하였습니다.

### 사유
- Spring의 트랜잭션 관리 기능을 명확하게 사용하기 위해 import 경로를 일관성 있게 정리하였습니다.
- 기능상 변화는 없으며, 코드 가독성과 유지보수성을 위한 사소한 수정입니다.
