### PR TITLE
feat: 메시지 읽음 처리 추가

### DIFF
--- a/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
@@ -17,6 +17,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -32,10 +35,10 @@ public class MessageController {
     private final ChatMessageService chatMessageService;
 
     @Operation(summary = "채팅방 메시지 전체 조회", description = "특정 채팅방의 모든 메시지를 조회합니다.")
-    @GetMapping("/{roomId}")
+    @GetMapping("/{roomId}/{userId}")
     @ApiVersion(2)
-    public List<MessageResponse> getMessagesByRoom(@PathVariable String roomId) {
-        return messageService.getMessagesByRoomId(roomId);
+    public List<MessageResponse> getMessagesByRoom(@PathVariable String roomId, @PathVariable String userId) {
+        return messageService.getMessagesByRoomId(roomId, userId);
     }
     @GetMapping("/{roomId}")
     @ApiVersion(1)
@@ -63,5 +66,11 @@ public class MessageController {
         messagingTemplate.convertAndSend("/topic/chat/" + messageRequest.getRoomId(), savedMessage);
         // 모든 인스턴스에 메시지 동기화 (Redis Pub/Sub)
         chatMessageService.publishChatMessage(messageRequest.getRoomId(), savedMessage);
+    }
+
+    @PostMapping("/{roomId}/{userId}/read")
+    public ResponseEntity<Void> markAsRead(@PathVariable String roomId, @PathVariable String userId, @RequestBody String lastReadMessageId) {
+        messageService.markAsRead(roomId, userId, lastReadMessageId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
+++ b/src/main/java/com/sesac/carematching/chat/controller/MessageController.java
@@ -8,8 +8,10 @@ import com.sesac.carematching.config.ApiVersion;
 import com.sesac.carematching.exception.VersionException;
 import com.sesac.carematching.user.User;
 import com.sesac.carematching.user.UserRepository;
+import com.sesac.carematching.util.TokenAuth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -35,12 +37,14 @@ public class MessageController {
     private final SimpMessagingTemplate messagingTemplate;
     private final UserRepository userRepository;
     private final ChatMessageService chatMessageService;
+    private final TokenAuth tokenAuth;
 
     @Operation(summary = "채팅방 메시지 전체 조회", description = "특정 채팅방의 모든 메시지를 조회합니다.")
-    @GetMapping("/{roomId}/{userId}")
+    @GetMapping("/{roomId}")
     @ApiVersion(2)
-    public List<MessageResponse> getMessagesByRoom(@PathVariable String roomId, @PathVariable String userId) {
-        return messageService.getMessagesByRoomId(roomId, userId);
+    public List<MessageResponse> getMessagesByRoom(@PathVariable String roomId, HttpServletRequest request) {
+        String username = tokenAuth.extractUsernameFromToken(request);
+        return messageService.getMessagesByRoomId(roomId, username);
     }
     @GetMapping("/{roomId}")
     @ApiVersion(1)

--- a/src/main/java/com/sesac/carematching/chat/dto/MessageResponse.java
+++ b/src/main/java/com/sesac/carematching/chat/dto/MessageResponse.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-
 public class MessageResponse {
     private String roomId;
     private String username;
@@ -14,7 +13,27 @@ public class MessageResponse {
     private String createdAt;
     private String createdDate; // 월/일 (예: "06/18")
     private String createdTime; // 시/분 (예: "14:45")
+    private boolean isRead; // 메시지 읽음 여부
 
+    public MessageResponse(
+            @NotNull String roomId,
+            @NotNull String username,
+            @NotNull String message,
+            @NotNull String createdAt,
+            @NotNull String createdDate,
+            @NotNull String createdTime,
+            boolean isRead
+    ) {
+        this.roomId = roomId;
+        this.username = username; // ✅ userId 제거, username만 반환
+        this.message = message;
+        this.createdAt = createdAt;
+        this.createdDate = createdDate;
+        this.createdTime = createdTime;
+        this.isRead = isRead;
+    }
+
+    // 기존 호출을 위한 오버로드: 기본적으로 isRead=false
     public MessageResponse(
             @NotNull String roomId,
             @NotNull String username,
@@ -23,11 +42,6 @@ public class MessageResponse {
             @NotNull String createdDate,
             @NotNull String createdTime
     ) {
-        this.roomId = roomId;
-        this.username = username; // ✅ userId 제거, username만 반환
-        this.message = message;
-        this.createdAt = createdAt;
-        this.createdDate = createdDate;
-        this.createdTime = createdTime;
+        this(roomId, username, message, createdAt, createdDate, createdTime, false);
     }
 }

--- a/src/main/java/com/sesac/carematching/chat/message/ChatReadStatus.java
+++ b/src/main/java/com/sesac/carematching/chat/message/ChatReadStatus.java
@@ -1,0 +1,21 @@
+package com.sesac.carematching.chat.message;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Document(collection = "chat_read_status")
+public class ChatReadStatus {
+    @Id
+    private String id; // optional Mongo id
+
+    private String roomId;
+    private String userId;
+    private String lastReadMessageId;
+    private Instant readAt;
+}

--- a/src/main/java/com/sesac/carematching/chat/message/ChatReadStatus.java
+++ b/src/main/java/com/sesac/carematching/chat/message/ChatReadStatus.java
@@ -16,6 +16,5 @@ public class ChatReadStatus {
 
     private String roomId;
     private String userId;
-    private String lastReadMessageId;
     private Instant readAt;
 }

--- a/src/main/java/com/sesac/carematching/chat/message/ChatReadStatusRepository.java
+++ b/src/main/java/com/sesac/carematching/chat/message/ChatReadStatusRepository.java
@@ -1,0 +1,11 @@
+package com.sesac.carematching.chat.message;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChatReadStatusRepository extends MongoRepository<ChatReadStatus, String> {
+    Optional<ChatReadStatus> findByRoomIdAndUserId(String roomId, String userId);
+}

--- a/src/main/java/com/sesac/carematching/chat/service/MessageService.java
+++ b/src/main/java/com/sesac/carematching/chat/service/MessageService.java
@@ -9,5 +9,11 @@ public interface MessageService {
 
     MessageResponse saveMessage(MessageRequest messageRequest);
 
-    List<MessageResponse> getMessagesByRoomId(String roomId);
+    List<MessageResponse> getMessagesByRoomId(String roomId, String userId);
+
+    /**
+     * 사용자가 특정 메시지까지 읽었다고 표시(마지막 읽음 메시지 ID 전달).
+     * 구현은 Redis에 해당 메시지의 createdAt epochMillis를 저장합니다.
+     */
+    void markAsRead(String roomId, String userId, String lastReadMessageId);
 }

--- a/src/main/java/com/sesac/carematching/chat/service/MessageService.java
+++ b/src/main/java/com/sesac/carematching/chat/service/MessageService.java
@@ -15,5 +15,5 @@ public interface MessageService {
      * 사용자가 특정 메시지까지 읽었다고 표시(마지막 읽음 메시지 ID 전달).
      * 구현은 Redis에 해당 메시지의 createdAt epochMillis를 저장합니다.
      */
-    void markAsRead(String roomId, String userId, String lastReadMessageId);
+    void markAsRead(String roomId, String userId, Long lastReadEpochMillis);
 }

--- a/src/main/java/com/sesac/carematching/chat/service/MessageServiceImpl.java
+++ b/src/main/java/com/sesac/carematching/chat/service/MessageServiceImpl.java
@@ -80,23 +80,41 @@ public class MessageServiceImpl implements MessageService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MessageResponse> getMessagesByRoomId(String roomId) {
+    public List<MessageResponse> getMessagesByRoomId(String roomId, String userId) {
+        // 사용자의 마지막 읽은 메시지 ID 조회
+        String lastReadMessageId = getLastReadMessageId(roomId, userId);
         return messageRepository.findByRoomId(roomId).stream()
             .map(message -> {
-                // 각 메시지마다 생성시간 포맷팅
                 String formattedDate = message.getCreatedAt()
                     .atZone(ZoneId.systemDefault())
                     .format(dateFormatter);
                 String formattedTime = message.getCreatedAt()
                     .atZone(ZoneId.systemDefault())
                     .format(timeFormatter);
+                boolean isRead = false;
+                if (lastReadMessageId != null) {
+                    // lastReadMessageId는 MongoDB의 message id(ObjectId 문자열)로 저장될 수 있으므로,
+                    // 안전하게 createdAt(Instant) 기준으로 비교합니다. Redis에는 message id가 아닌 createdAt epochMillis를 저장하는
+                    // 방식으로 변경하는 것이 더 안전하지만, 현재는 lastReadMessageId가 메시지 id라면 MongoDB에서 해당 메시지를 조회하여
+                    // 그 메시지의 createdAt을 사용하여 비교할 수 있습니다. 간단하게는 문자열 비교를 피하기 위해 try-catch를 사용합니다.
+                    try {
+                        // Redis에 저장된 값이 epochMillis(숫자)인 경우
+                        long lastReadEpoch = Long.parseLong(lastReadMessageId);
+                        long messageEpoch = message.getCreatedAt().toEpochMilli();
+                        isRead = messageEpoch <= lastReadEpoch;
+                    } catch (NumberFormatException e) {
+                        // 저장된 값이 ObjectId 문자열일 경우, 비교 불가이므로 false로 처리
+                        isRead = false;
+                    }
+                }
                 return new MessageResponse(
                     message.getRoomId(),
                     message.getUsername(),
                     message.getMessage(),
                     message.getCreatedAt().toString(),
                     formattedDate,
-                    formattedTime
+                    formattedTime,
+                    isRead
                 );
             })
             .collect(Collectors.toList());
@@ -117,14 +135,58 @@ public class MessageServiceImpl implements MessageService {
     }
 
     // 사용자의 마지막 읽은 메시지 ID를 Redis에 저장
+    // 단, 전달된 값이 epochMillis(숫자)라면 기존 값보다 클 때만 갱신합니다.
     private void setLastReadMessageId(String roomId, String userId, String messageId) {
         String key = String.format(READ_KEY_FORMAT, roomId, userId);
-        redisTemplate.opsForValue().set(key, messageId);
+        if (messageId == null) return;
+        try {
+            long newEpoch = Long.parseLong(messageId);
+            String current = redisTemplate.opsForValue().get(key);
+            if (current == null) {
+                redisTemplate.opsForValue().set(key, String.valueOf(newEpoch));
+                return;
+            }
+            try {
+                long currentEpoch = Long.parseLong(current);
+                if (newEpoch > currentEpoch) {
+                    redisTemplate.opsForValue().set(key, String.valueOf(newEpoch));
+                }
+                return;
+            } catch (NumberFormatException ex) {
+                // 현재 값이 숫자가 아니면 덮어쓰기
+                redisTemplate.opsForValue().set(key, String.valueOf(newEpoch));
+                return;
+            }
+        } catch (NumberFormatException e) {
+            // 전달된 값이 숫자가 아닐 경우(예: 메시지 id 문자열), 그대로 저장
+            redisTemplate.opsForValue().set(key, messageId);
+        }
     }
 
     // 사용자의 마지막 읽은 메시지 ID를 Redis에서 조회
     private String getLastReadMessageId(String roomId, String userId) {
         String key = String.format(READ_KEY_FORMAT, roomId, userId);
         return redisTemplate.opsForValue().get(key);
+    }
+
+    @Override
+    public void markAsRead(String roomId, String userId, String lastReadMessageId) {
+        // lastReadMessageId가 MongoDB 메시지 id일 수 있으므로, 해당 메시지를 찾아 createdAt epochMillis를 Redis에 저장
+        try {
+            // 먼저 메시지 id를 기준으로 MongoDB에서 조회 시도
+            Message msg = messageRepository.findById(lastReadMessageId).orElse(null);
+            if (msg != null) {
+                long epochMillis = msg.getCreatedAt().toEpochMilli();
+                String key = String.format(READ_KEY_FORMAT, roomId, userId);
+                redisTemplate.opsForValue().set(key, String.valueOf(epochMillis));
+                return;
+            }
+        } catch (Exception ignored) {
+            // 조회 실패 시에도 다음 단계로 넘어감
+        }
+
+        // 메시지 id로 조회되지 않는 경우(lastReadMessageId가 epochMillis 문자열일 수 있음), 그대로 저장
+        String key = String.format(READ_KEY_FORMAT, roomId, userId);
+        redisTemplate.opsForValue().set(key, lastReadMessageId);
     }
 }

--- a/src/main/java/com/sesac/carematching/chat/service/ReadStatusSyncService.java
+++ b/src/main/java/com/sesac/carematching/chat/service/ReadStatusSyncService.java
@@ -1,0 +1,100 @@
+package com.sesac.carematching.chat.service;
+
+import com.sesac.carematching.chat.message.ChatReadStatus;
+import com.sesac.carematching.chat.message.ChatReadStatusRepository;
+import com.sesac.carematching.chat.message.Message;
+import com.sesac.carematching.chat.message.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ReadStatusSyncService {
+    private static final Logger log = LoggerFactory.getLogger(ReadStatusSyncService.class);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ChatReadStatusRepository readStatusRepository;
+    private final MessageRepository messageRepository;
+
+    private static final String READ_KEY_FORMAT = "chat:read:%s:%s";
+    private static final String UPDATED_SET = "chat:read:updated";
+    private static final String DEAD_SET = "chat:read:dead";
+
+    // 매 5분마다 실행
+    @Scheduled(fixedDelayString = "PT5M")
+    public void syncReadStatusToMongo() {
+        log.info("Start syncReadStatusToMongo (ZPOP_MIN)");
+        try {
+            int batch = 500;
+            while (true) {
+                java.util.Set<ZSetOperations.TypedTuple<String>> popped = redisTemplate.opsForZSet().popMin("chat:read:updated", batch);
+                if (popped == null || popped.isEmpty()) break;
+                for (ZSetOperations.TypedTuple<String> t : popped) {
+                    String member = t.getValue();
+                    Double score = t.getScore();
+                    try {
+                        if (member == null || member.trim().isEmpty()) {
+                            log.warn("Skipping empty member from {}", UPDATED_SET);
+                            continue;
+                        }
+                        String[] parts = member.split(":");
+                        if (parts.length < 2) {
+                            log.warn("Malformed member {} moving to dead set", member);
+                            redisTemplate.opsForZSet().remove(UPDATED_SET, member);
+                            redisTemplate.opsForZSet().add(DEAD_SET, member, score == null ? System.currentTimeMillis() : score);
+                            continue;
+                        }
+                        String roomId = parts[0];
+                        String userId = parts[1];
+
+                        String key = String.format(READ_KEY_FORMAT, roomId, String.valueOf(userId));
+                        String value = redisTemplate.opsForValue().get(key);
+                        if (value == null) continue;
+
+                        ChatReadStatus status = readStatusRepository.findByRoomIdAndUserId(roomId, userId)
+                            .orElseGet(() -> {
+                                ChatReadStatus crs = new ChatReadStatus();
+                                crs.setRoomId(roomId);
+                                crs.setUserId(userId);
+                                return crs;
+                            });
+
+                        boolean shouldSave = false;
+                        try {
+                            long epoch = Long.parseLong(value);
+                            Instant newReadAt = Instant.ofEpochMilli(epoch);
+                            Instant existing = status.getReadAt();
+                            if (existing == null || newReadAt.isAfter(existing)) {
+                                status.setReadAt(newReadAt);
+                                shouldSave = true;
+                            }
+                        } catch (NumberFormatException e) {
+                            // legacy or malformed value — move to dead-letter to avoid infinite retry
+                            log.warn("Non-epoch value for key {} member {} moved to dead set: {}", key, member, value);
+                            redisTemplate.opsForZSet().add(DEAD_SET, member, score == null ? System.currentTimeMillis() : score);
+                            continue;
+                        }
+
+                        if (shouldSave) readStatusRepository.save(status);
+                    } catch (Exception e) {
+                        log.warn("Failed to process popped member {}: {}", member, e.getMessage());
+                        // unexpected failure (DB down etc.) — re-add for retry
+                        double s = score == null ? System.currentTimeMillis() : score;
+                        redisTemplate.opsForZSet().add(UPDATED_SET, member, s);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Sync failed: {}", e.getMessage());
+        }
+        log.info("End syncReadStatusToMongo (ZPOP_MIN)");
+    }
+}


### PR DESCRIPTION
## 한줄 요약
채팅 읽음 처리 로직을 개선하고, 읽음 동기화용 서비스(`ReadStatusSyncService`)와 `ChatReadStatus` 엔티티 추가

## 상세 설명

### 주요 변경사항
- 클라이언트가 POST로 보낸 마지막 읽음(lastRead)을 숫자 epoch 또는 ISO Instant 문자열로 파싱하도록 개선 (`MessageController`)
- 읽음 상태를 Redis에 epochMillis 기반으로 저장·갱신하도록 변경했으며, 업데이트가 있을 때 ZSET("chat:read:updated")에 기록해 동기화 대상 목록을 관리 (`MessageServiceImpl`)
- 메시지 응답 DTO에 isRead 필드를 추가하고, 메시지 조회 시 상대방(partner)의 마지막 읽음(epoch)을 기준으로 각 메시지의 읽음 여부를 판단하도록 변경 (`MessageResponse`, `MessageServiceImpl`)
- Redis ZSET에서 변경분을 소모하여 MongoDB의 `chat_read_status` 컬렉션에 upsert하는 스케줄러 서비스 `ReadStatusSyncService` 추가. 잘못된 값(epoch시간이 아닌 값)은 무시해 무한 재시도 방지
- MongoDB 도메인 `ChatReadStatus`와 repository를 추가

### 디자인 의도
- Redis를 쓰는 이유: 빠른 실시간 갱신과 다수 인스턴스 사이의 일시적 상태 공유.
- ZSET을 통해 변경 기록을 수집하고 백그라운드에서 MongoDB에 저장(upsert)하여 DB 부하를 분산. 
  - 기존: 모든 채팅방의 "읽음" 기록을 5분마다 동기화
  - 문제: 채팅방의 갯수에 따라 선형적으로 처리량 증가
  - 해결: Redis에 새 정보가 추가된 시점도 저장하여, 마지막으로 동기화한 시간 이후에 추가된 정보만 MongoDB에 동기화 작업 진행

## 변경된 파일 (주요)
- `MessageController.java` — `/api/message/read` API 제공(epoch/ISO 시간 지원)
- `MessageService.java` — `markAsRead` 메서드 추가
- `MessageServiceImpl.java` — Redis 저장/조회 로직 추가, partner 기반 isRead 판단, ZSET 업데이트 추가
- `MessageResponse.java` — isRead 필드 추가
- `ChatReadStatus.java` — MongoDB 도메인(새 컬렉션)
- `ChatReadStatusRepository.java` — MongoDB repository
- `ReadStatusSyncService.java` — Redis ZSET -> MongoDB upsert 스케줄러(배치 처리)

## 마이그레이션 / 운영 주의사항
- 새로운 MongoDB 컬렉션 `chat_read_status`가 생성됨. 별도 DB 마이그레이션 스크립트 불필요(스키마리스).
- 스케줄러(`@Scheduled`)가 동작하려면 애플리케이션에 스케줄링 활성화(`@EnableScheduling`)가 필요 (현재 프로젝트에는 이미 반영됨)
- Redis 키:
  - 읽음 값: `chat:read:{roomId}:{userId}` (value: epochMillis 또는 legacy messageId string)
  - 업데이트 트래킹: ZSET `chat:read:updated`

## 보완 예정 (후속)
- ReadStatusSyncService 예외 처리/모니터링을 보강(재시도 정책, 메트릭) 권장
- ZSET 크기/데이터 보관 정책(만료, 청소) 고려 필요