### PR TITLE
feat: Redis 커넥션 풀 추가 및 Redis 설정을 application.yaml로 자동 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.2'
 
+	// commons-pool2 for Lettuce pooling
+	implementation 'org.apache.commons:commons-pool2:2.11.1'
+
     // MongoDB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 

--- a/src/main/java/com/sesac/carematching/chat/config/RedisConfig.java
+++ b/src/main/java/com/sesac/carematching/chat/config/RedisConfig.java
@@ -2,52 +2,20 @@ package com.sesac.carematching.chat.config;
 
 import com.sesac.carematching.chat.pubsub.ChatMessageSubscriber;
 import com.sesac.carematching.chat.pubsub.NotificationSubscriber;
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.SocketOptions;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
-import java.time.Duration;
-
 @Configuration
 public class RedisConfig {
 
-    @Value("${redis.host}")
-    private String redisHost;
-
-    @Value("${redis.port}")
-    private int redisPort;
-
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration server = new RedisStandaloneConfiguration(redisHost, redisPort);
-
-        LettuceClientConfiguration client = LettuceClientConfiguration.builder()
-            .commandTimeout(Duration.ofSeconds(2))
-            .clientOptions(ClientOptions.builder()
-                .autoReconnect(true)
-                .socketOptions(SocketOptions.builder()
-                    .connectTimeout(Duration.ofSeconds(1))
-                    .build())
-                .build())
-            .shutdownTimeout(Duration.ofMillis(300))
-            .build();
-
-        return new LettuceConnectionFactory(server, client);
-    }
-
     @Bean
     public StringRedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
-        return new StringRedisTemplate(connectionFactory); // ✅ StringRedisTemplate 빈 등록
+        return new StringRedisTemplate(connectionFactory);
     }
 
     @Bean

--- a/src/main/java/com/sesac/carematching/chat/service/MessageServiceImpl.java
+++ b/src/main/java/com/sesac/carematching/chat/service/MessageServiceImpl.java
@@ -5,7 +5,6 @@ import com.sesac.carematching.chat.dto.MessageRequest;
 import com.sesac.carematching.chat.dto.MessageResponse;
 import com.sesac.carematching.chat.message.Message;
 import com.sesac.carematching.chat.message.MessageRepository;
-import com.sesac.carematching.chat.pubsub.RedisPublisherService;
 import com.sesac.carematching.chat.room.Room;
 import com.sesac.carematching.chat.room.RoomRepository;
 import com.sesac.carematching.user.User;
@@ -13,7 +12,6 @@ import com.sesac.carematching.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import com.sesac.carematching.chat.config.ApplicationInstance;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.ZoneId;
@@ -29,10 +27,7 @@ public class MessageServiceImpl implements MessageService {
     private final MessageRepository messageRepository;
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
-    private final RedisPublisherService redisPublisherService;
-    private final ObjectMapper objectMapper;
     private final StringRedisTemplate redisTemplate;
-    private final ApplicationInstance applicationInstance;
 
     // DateTimeFormatter를 한 번만 생성해두고 재사용
     private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("MM/dd");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,17 @@ spring:
   sql:
     init:
       mode: always
+  redis:
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
+    timeout: 2s
+    lettuce:
+      shutdown-timeout: 300ms
+      pool:
+        max-active: 20
+        max-idle: 10
+        min-idle: 5
+        max-wait: 500ms
 
 springdoc:
   api-docs:
@@ -64,10 +75,6 @@ cloud:
       auto: false
     stack:
       auto: false
-
-redis:
-  host: ${REDIS_HOST:localhost}
-  port: ${REDIS_PORT:6379}
 
 toss:
   secret: ${TOSS_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,17 +37,18 @@ spring:
   sql:
     init:
       mode: always
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
-    timeout: 300ms
-    lettuce:
-      shutdown-timeout: 100ms
-      pool:
-        max-active: 3
-        max-idle: 1
-        min-idle: 1
-        max-wait: 300ms
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 300ms
+      lettuce:
+        shutdown-timeout: 100ms
+        pool:
+          max-active: 3
+          max-idle: 1
+          min-idle: 1
+          max-wait: 300ms
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,14 +40,14 @@ spring:
   redis:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}
-    timeout: 2s
+    timeout: 300ms
     lettuce:
-      shutdown-timeout: 300ms
+      shutdown-timeout: 100ms
       pool:
-        max-active: 20
-        max-idle: 10
-        min-idle: 5
-        max-wait: 500ms
+        max-active: 3
+        max-idle: 1
+        min-idle: 1
+        max-wait: 300ms
 
 springdoc:
   api-docs:


### PR DESCRIPTION
### 요약
- Lettuce 커넥션 풀을 사용하도록 Redis 설정을 정리하고, 수동으로 등록하던 `RedisConnectionFactory` 빈을 제거하여 Spring Boot의 `application.yaml` 기반 자동 구성을 사용하도록 변경
- Lettuce 풀을 지원하기 위한 `commons-pool2` 의존성 추가

### 변경 파일
- build.gradle — Lettuce 풀 사용을 위한 `org.apache.commons:commons-pool2` 의존성 추가
- RedisConfig.java — 직접 생성하던 `RedisConnectionFactory` 빈 코드 제거, `StringRedisTemplate` 빈 유지
- application.yaml — Redis 호스트/포트, 타임아웃, lettuce shutdown/pool 관련 프로퍼티 추가

### 변경 이유
- Spring Boot의 자동구성을 활용해 설정을 중앙에서 관리
- Lettuce 커넥션 풀을 활성화해 Redis 연결 안정성과 성능 개선

### Connection Pool 부하테스트 실험
구분 | 처리량 (초당) | 평균 (ms) | 상위 95% (ms) | 상위 99% (ms)
-- | -- | -- | -- | --
요청마다 커넥션 생성 | 129.7 | 143.753 | 153.561 | 167.241
커넥션 재사용 | 7,303.2 | 2.738 | 3.660 | 4.455
성능 향상 비율 | 56.3배 | 52.5배 | 42배 | 37.5배
